### PR TITLE
chore(cleanup): restore sample posts and ignore from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 
-# sample content
-src/content/blog/samples/
+# Astro template samples (keep locally, don’t version)
+src/content/blog/markdown-style-guide.md
+src/content/blog/using-mdx.mdx


### PR DESCRIPTION
- moved Astro sample posts back to src/content/blog/
- added markdown-style-guide.md, using-mdx.mdx to .gitignore
- keep samples locally for reference, but exclude from version control